### PR TITLE
Use authenticated mode and GCM, and drop support for encrypting with RSA directly

### DIFF
--- a/secrets.js
+++ b/secrets.js
@@ -21,39 +21,26 @@ async function main() {
     // Encrypt data using the recipient's public key.
     const key = fs.readFileSync(keyFile, {encoding: 'utf8'});
     const plaintext = fs.readFileSync(0);
-    try {
-      const encrypted = crypto.publicEncrypt({key}, plaintext).toString('base64');
-      console.log(encrypted);
-    } catch (e) {
-      if (!/data too large/.test(e.message)) { throw e; }
-      // For too large data, generate and encrypt a symmetric key first.
-      const symKey = crypto.randomBytes(32);
-      const encryptedKey = crypto.publicEncrypt({key}, symKey).toString('base64');
+    const symKey = crypto.randomBytes(32);
+    const encryptedKey = crypto.publicEncrypt({key}, symKey).toString('base64');
 
-      const iv = crypto.randomBytes(16);
-      const cipher = crypto.createCipheriv('aes-256-gcm', symKey, iv);
-      let encryptedText = cipher.update(plaintext, 'utf8', 'base64');
-      encryptedText += cipher.final('base64');
-      const authTag = cipher.getAuthTag().toString('base64');
-      console.log(`$${iv.toString('base64')}$${encryptedKey}$${encryptedText}$${authTag}`);
-    }
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', symKey, iv);
+    let encryptedText = cipher.update(plaintext, 'utf8', 'base64');
+    encryptedText += cipher.final('base64');
+    const authTag = cipher.getAuthTag().toString('base64');
+    console.log(`$${iv.toString('base64')}$${encryptedKey}$${encryptedText}$${authTag}`);
 
   } else if (command === 'decrypt') {
     // Decrypt data using your own private key.
     const key = fs.readFileSync(keyFile, {encoding: 'utf8'});
     const fullText = fs.readFileSync(0, {encoding: 'utf8'})
-    let plaintext;
-    if (fullText.startsWith('$')) {
-      const [ivText, encryptedKey, encryptedText, authTag] = fullText.split('$').slice(1);
-      const iv = Buffer.from(ivText, 'base64');
-      const symKey = crypto.privateDecrypt({key}, Buffer.from(encryptedKey, 'base64'));
-      const decipher = crypto.createDecipheriv('aes-256-gcm', symKey, iv);
-      plaintext = decipher.setAuthTag(authTag, 'base64').update(encryptedText, 'base64', 'utf8');
-      plaintext += decipher.final('utf8');
-    } else {
-      const encrypted = Buffer.from(fullText, 'base64');
-      plaintext = crypto.privateDecrypt({key}, encrypted);
-    }
+    const [ivText, encryptedKey, encryptedText, authTag] = fullText.split('$').slice(1);
+    const iv = Buffer.from(ivText, 'base64');
+    const symKey = crypto.privateDecrypt({key}, Buffer.from(encryptedKey, 'base64'));
+    const decipher = crypto.createDecipheriv('aes-256-gcm', symKey, iv);
+    let plaintext = decipher.setAuthTag(authTag, 'base64').update(encryptedText, 'base64', 'utf8');
+    plaintext += decipher.final('utf8');
     fs.writeFileSync(1, plaintext);
 
   } else if (command === 'genkey') {


### PR DESCRIPTION
- Switch from aes-256-cbc to aes-256-gcm and include authTag, for authenticated mode.
- Drop support for encrypting small secrets with the public key directly. It was there for historical reasons, adds no benefit, and raises questions.